### PR TITLE
fix(diag): AGH перед прошивочным прокси — это не рассинхрон

### DIFF
--- a/files/z2k-diag.sh
+++ b/files/z2k-diag.sh
@@ -1568,15 +1568,67 @@ print_insta_pins() {
     fi
 }
 
-# AdGuard Home. Если он стоит, 53-й порт держит он, а встроенный dns-proxy
-# прошивки штатно отключается — и записи `ip host`, на которых держится обход
-# Instagram и веб-WhatsApp, не спрашивает НИКТО: они целы и бесполезны, клиент
-# получает подменённый провайдером адрес. Снаружи это неотличимо от «обход не
-# работает», в логах z2k при этом ровно ничего. Разбор такого случая у живого
-# пользователя занял час именно потому, что в сводке не было видно ни AGH, ни
-# того, что наши пины перекрыты.
+# AdGuard Home. Он перехватывает DNS у клиентов, а записи `ip host`, на которых
+# держится обход Instagram и веб-WhatsApp, применяет dns-proxy прошивки. Что из
+# этого выйдет — зависит от того, где именно стоит AGH:
+#
+#   1. AGH забрал 53-й порт, dns-proxy прошивки штатно отключён, наружу AGH
+#      ходит сам. Тогда `ip host` не спрашивает НИКТО: записи целы и бесполезны,
+#      клиент получает подменённый провайдером адрес. Снаружи это неотличимо от
+#      «обход не работает», в логах z2k при этом ровно ничего. Разбор такого
+#      случая у живого пользователя занял час именно потому, что в сводке не
+#      было видно ни AGH, ни того, что наши пины перекрыты.
+#
+#   2. AGH стоит ПЕРЕД прошивочным прокси: слушает свой порт (обычно 5300, а
+#      клиентов заворачивает REDIRECT в firewall), а `upstream_dns` у него —
+#      127.0.0.1:53, то есть тот самый dns-proxy. Пины применяются ниже по
+#      цепочке и доезжают до клиента ровно так же, как без AGH.
+#
+# ЧТО БЫЛО. Считались только записи в `rewrites:`, и во второй схеме сводка
+# объявляла рабочему роутеру «обход Instagram/WhatsApp работать не будет».
+# Рефрешер в rewrites ничего не пишет и не должен (см. шапку
+# z2k-insta-ip-refresh.sh — он правит `ip host`), поэтому счёт `0/N` и крик
+# получал КАЖДЫЙ пользователь с такой схемой, независимо от того, работает у
+# него обход или нет. Проверено пакетом на живом роутере: ответ AGH на
+# www.instagram.com равен записи `ip host`, а TTL в нём на несколько секунд
+# меньше — это его кэш ответа прошивочного прокси.
+#
+# Ложная тревога в диагностике дороже отсутствующей строки: по ней идут чинить
+# то, что не сломано, и добавляют в AGH статические rewrites, которые назавтра
+# протухнут и начнут перебивать свежие `ip host`. Поэтому приговор зависит и от
+# того, остался ли прошивочный прокси в цепочке, — это видно по `upstream_dns`
+# в том же yaml, который уже открыт. А сама та починка — протухшие rewrites поверх
+# свежих `ip host` — теперь ловится отдельной строкой: см. счёт расхождений ниже.
+
+# Ведёт ли апстрим AGH обратно в dns-proxy прошивки. Петля на 53-й порт здесь
+# не ошибка конфигурации, а штатная схема: именно через неё доезжает `ip host`.
+# Разобрать надо все формы, которыми это записывают: 127.0.0.1, 127.0.0.1:53,
+# [::1]:53, udp://127.0.0.1:53 и доменный селектор AGH `[/domain/]127.0.0.1:53`.
+agh_upstream_is_local() {
+    local u="$1" host port
+    case "$u" in
+        \[/*\]*) u="${u#*\]}" ;;
+    esac
+    case "$u" in
+        udp://*|tcp://*) u="${u#*://}" ;;
+        *://*) return 1 ;;
+    esac
+    case "$u" in
+        \[*\]:*) host="${u%%\]*}"; host="${host#\[}"; port="${u##*\]:}" ;;
+        \[*\])   host="${u#\[}"; host="${host%\]}"; port=53 ;;
+        *:*:*)   host="$u"; port=53 ;;
+        *:*)     host="${u%:*}"; port="${u##*:}" ;;
+        *)       host="$u"; port=53 ;;
+    esac
+    [ "$port" = 53 ] || return 1
+    case "$host" in
+        127.*|::1|0:0:0:0:0:0:0:1|localhost) return 0 ;;
+    esac
+    return 1
+}
+
 print_agh() {
-    local y c hosts pinned inagh cmp n_pin n_hit state
+    local y c hosts pinned inagh cmp n_pin n_hit n_bad state ups upf u n_up n_uploc uploc
     y=""
     for c in "${Z2K_AGH_YAML:-}" /opt/etc/AdGuardHome/AdGuardHome.yaml \
              /opt/AdGuardHome/AdGuardHome.yaml /opt/var/AdGuardHome/AdGuardHome.yaml \
@@ -1625,17 +1677,69 @@ print_agh() {
             else if (k == "answer") a = v
             if (d != "" && a != "" && (d in own)) { print d "\t" a; d = "" }
         }' "$y" 2>/dev/null)
+    # Апстримы — из того же файла, который уже открыт. Ни одного сетевого
+    # запроса: сводку гоняют и на роутере без интернета, и она обязана
+    # оставаться быстрой и одинаковой.
+    ups=$(awk '
+        function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t\r]+$/, "", s); return s }
+        function unq(s) { gsub(/"/, "", s); gsub(Q, "", s); return s }
+        BEGIN { Q = sprintf("%c", 39)
+                KRX = "^[ \t]*[\"" Q "]?upstream_dns[\"" Q "]?[ \t]*:" }
+        !inb && $0 ~ KRX { inb = 1; kin = match($0, /[^ \t]/) - 1; next }
+        inb {
+            t = trim($0)
+            if (t == "" || substr(t, 1, 1) == "#") next
+            cur = match($0, /[^ \t]/) - 1
+            if (cur < kin || (cur == kin && substr(t, 1, 1) != "-")) { inb = 0; next }
+            if (substr(t, 1, 1) != "-") next
+            v = unq(trim(substr(t, 2)))
+            if (v != "") print v
+        }' "$y" 2>/dev/null)
+    # upstream_dns_file: у части людей список апстримов вынесен в отдельный
+    # файл, и без него схема с прошивочным прокси выглядела бы как «апстримов
+    # нет» — то есть снова ложная тревога.
+    upf=$(sed -n 's/^[[:space:]]*upstream_dns_file[[:space:]]*:[[:space:]]*//p' "$y" 2>/dev/null \
+          | head -1 | tr -d "\"' 	")
+    if [ -n "$upf" ] && [ -r "$upf" ]; then
+        ups="$ups
+$(sed 's/#.*//' "$upf" 2>/dev/null)"
+    fi
+    n_up=0; n_uploc=0; uploc=""
+    for u in $ups; do
+        n_up=$((n_up + 1))
+        if agh_upstream_is_local "$u"; then
+            n_uploc=$((n_uploc + 1))
+            [ -n "$uploc" ] || uploc="$u"
+        fi
+    done
+    # Расхождение считаем отдельно: rewrites СИЛЬНЕЕ апстрима — AGH отвечает из
+    # них, никого не спрашивая. Поэтому запись по нашему домену с чужим адресом
+    # опаснее пустых rewrites: пины рефрешер обновляет каждую ночь, а вбитая
+    # руками копия остаётся с адресами прошлой недели и перебивает свежий
+    # `ip host`. Именно так «чинят» по старой формулировке этой же строки —
+    # случай не гипотетический.
     cmp=$( { printf '%s\n' "$pinned" | sed 's/^/P /'
              printf '%s\n' "$inagh"  | sed 's/^/A /'; } \
            | awk '$1 == "P" && NF == 3 { p[$2 " " $3] = 1; np++ }
                   $1 == "A" && NF == 3 { a[$2 " " $3] = 1 }
-                  END { for (k in p) if (k in a) h++; printf "%d %d", np + 0, h + 0 }')
-    n_pin=${cmp%% *}; n_hit=${cmp##* }
+                  END { for (k in p) if (k in a) h++
+                        for (k in a) if (!(k in p)) x++
+                        printf "%d %d %d", np + 0, h + 0, x + 0 }')
+    n_pin=${cmp%% *}; n_hit=${cmp#* }; n_bad=${n_hit#* }; n_hit=${n_hit%% *}
     if [ "$n_pin" = 0 ]; then
         printf 'AdGuardHome       : %s, наших ip host нет — сверять нечего\n' "$state"
+    elif [ "$n_bad" -gt 0 ]; then
+        printf 'AdGuardHome       : %s, в rewrites %s записей по нашим доменам расходятся с ip host: rewrites сильнее апстрима, клиент получит их адреса — обход Instagram/WhatsApp сломается\n' \
+            "$state" "$n_bad"
     elif [ "$n_hit" = "$n_pin" ]; then
         printf 'AdGuardHome       : %s, наши записи в rewrites: %s/%s — синхронизированы\n' \
             "$state" "$n_hit" "$n_pin"
+    elif [ "$n_up" -gt 0 ] && [ "$n_uploc" = "$n_up" ]; then
+        printf 'AdGuardHome       : %s, в rewrites %s/%s — и это норма: апстрим %s ведёт в dns-proxy прошивки, ip host применяется там\n' \
+            "$state" "$n_hit" "$n_pin" "$uploc"
+    elif [ "$n_uploc" -gt 0 ]; then
+        printf 'AdGuardHome       : %s, в rewrites %s/%s, а в dns-proxy прошивки ведут %s апстрима из %s: на остальных запросах ip host не применяется — обход Instagram/WhatsApp будет работать через раз\n' \
+            "$state" "$n_hit" "$n_pin" "$n_uploc" "$n_up"
     else
         printf 'AdGuardHome       : %s, наши записи в rewrites: %s/%s — НЕ синхронизированы: AGH отвечает клиентам мимо ip host, обход Instagram/WhatsApp работать не будет\n' \
             "$state" "$n_hit" "$n_pin"

--- a/tests/test_diag_agh_upstream.sh
+++ b/tests/test_diag_agh_upstream.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+# tests/test_diag_agh_upstream.sh — приговор про AdGuard Home обязан учитывать,
+# остался ли dns-proxy прошивки в цепочке.
+#
+# ЧТО БЫЛО. Строка считала только записи в `rewrites:` файла AdGuardHome.yaml и
+# при нехватке объявляла: «AGH отвечает клиентам мимо ip host, обход
+# Instagram/WhatsApp работать не будет». Для схемы «AGH забрал 53-й порт и ходит
+# наружу сам» это верно. Но у части людей AGH стоит ПЕРЕД прошивочным прокси:
+# слушает 5300, клиентов заворачивает REDIRECT, а `upstream_dns` — 127.0.0.1:53.
+# Там пины применяются ниже по цепочке и доезжают до клиента, а рефрешер в
+# rewrites не пишет и не должен — значит счёт `0/N` и крик получал КАЖДЫЙ такой
+# пользователь на рабочем роутере. Проверено пакетом на живом роутере: ответ AGH
+# на www.instagram.com равен записи `ip host`, TTL на несколько секунд меньше —
+# кэш ответа прошивочного прокси.
+#
+# Проверяется ИСПОЛНЕНИЕМ настоящих функций из files/z2k-diag.sh с подставными
+# ndmc и AdGuardHome.yaml.
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '[PASS] %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '[FAIL] %s\n' "$1"; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SB=$(mktemp -d) || exit 1
+trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB/bin"
+
+cat > "$SB/bin/ndmc" <<'STUB'
+#!/bin/sh
+cat "$NDM_CONF" 2>/dev/null
+STUB
+# Состояние AGH к приговору отношения не имеет, но пусть оно будет одинаковым
+# на машине разработчика и в CI — иначе набор зависит от того, что там запущено.
+cat > "$SB/bin/pidof" <<'STUB'
+#!/bin/sh
+exit 1
+STUB
+chmod +x "$SB/bin/ndmc" "$SB/bin/pidof"
+
+# Функции берём настоящие: тест сторожит поведение сводки, а не свою копию кода.
+for fn in insta_pinned agh_upstream_is_local print_agh; do
+    awk -v f="$fn" 'index($0, f "() {") == 1, /^\}/' "$ROOT/files/z2k-diag.sh" >> "$SB/blk.sh"
+    printf '\n' >> "$SB/blk.sh"
+done
+printf 'print_agh\n' >> "$SB/blk.sh"
+for fn in insta_pinned agh_upstream_is_local print_agh; do
+    grep -q "^${fn}() {" "$SB/blk.sh" || {
+        bad "не нашёл $fn в z2k-diag.sh — проверка ослепла"
+        printf '\nPASSED: %s\nFAILED: %s\n' "$PASS" "$FAIL"; exit 1; }
+done
+
+printf 'HOSTS="a.test b.test"\n' > "$SB/z2k-insta-ip-refresh.sh"
+PINS='ip host a.test 1.2.3.4
+ip host b.test 5.6.7.8'
+
+run() {  # run <yaml> [running-config]
+    printf '%s\n' "$1" > "$SB/agh.yaml"
+    printf '%s\n' "${2-$PINS}" > "$SB/ndm.conf"
+    env PATH="$SB/bin:$PATH" ZAPRET2_DIR="$SB" Z2K_AGH_YAML="$SB/agh.yaml" \
+        NDM_CONF="$SB/ndm.conf" "${Z2K_TEST_SH:-sh}" "$SB/blk.sh" 2>/dev/null
+}
+
+Y_LOCAL='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_EXTERNAL='dns:
+  upstream_dns:
+    - tls://1.1.1.1
+    - https://dns.google/dns-query
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_MIXED='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+    - 8.8.8.8
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_SYNCED='dns:
+  upstream_dns:
+    - tls://1.1.1.1
+  upstream_dns_file: ""
+filtering:
+  rewrites:
+    - domain: a.test
+      answer: 1.2.3.4
+    - domain: b.test
+      answer: 5.6.7.8'
+
+Y_FORMS='dns:
+  upstream_dns:
+    - "[::1]:53"
+    - udp://127.0.0.1
+    - "[/instagram.com/]127.0.0.1:53"
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_OTHER_LOCAL='dns:
+  upstream_dns:
+    - 127.0.0.1:5353
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+# Протухшая копия пинов в rewrites — то, что делают, «починив» роутер по старой
+# формулировке этой же строки. Апстрим при этом локальный, то есть без счёта
+# расхождений сводка сказала бы «и это норма».
+Y_STALE='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites:
+    - domain: a.test
+      answer: 9.9.9.9'
+
+# Все пины на месте, но рядом лежит лишняя устаревшая запись: AGH отдаст оба
+# адреса, и половина соединений уедет в мёртвый.
+Y_SYNCED_PLUS_STALE='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites:
+    - domain: a.test
+      answer: 1.2.3.4
+    - domain: a.test
+      answer: 9.9.9.9
+    - domain: b.test
+      answer: 5.6.7.8'
+
+# --- 1. Главный случай: AGH перед прошивочным прокси --------------------------
+# Это и есть исходный дефект: рабочему роутеру сообщалось «работать не будет».
+out=$(run "$Y_LOCAL")
+case "$out" in
+    *'работать не будет'*) bad "ложная тревога: апстрим 127.0.0.1:53, пины доезжают: [$out]" ;;
+    *'dns-proxy прошивки'*) ok "петля на 53-й порт распознана как штатная схема" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+case "$out" in
+    *'127.0.0.1:53'*) ok "апстрим показан значением, а не пересказан" ;;
+    *) bad "апстрим не показан: [$out]" ;;
+esac
+
+# --- 2. Настоящий диагноз сохранён --------------------------------------------
+# Ради этого случая строка и добавлялась: AGH ходит наружу сам, ip host мёртв.
+out=$(run "$Y_EXTERNAL")
+case "$out" in
+    *'НЕ синхронизированы'*) ok "AGH с внешними апстримами по-прежнему диагноз" ;;
+    *) bad "главный диагноз потерян: [$out]" ;;
+esac
+
+# --- 3. Часть апстримов внешняя — это не «всё хорошо» -------------------------
+out=$(run "$Y_MIXED")
+case "$out" in
+    *'через раз'*) ok "смешанные апстримы названы своим именем" ;;
+    *) bad "смешанные апстримы разобраны неверно: [$out]" ;;
+esac
+
+# --- 4. Пины продублированы в rewrites — прежний зелёный вердикт --------------
+out=$(run "$Y_SYNCED")
+case "$out" in
+    *'НЕ синхронизированы'*) bad "заполненные rewrites объявлены рассинхроном: [$out]" ;;
+    *'— синхронизированы'*) ok "заполненные rewrites по-прежнему синхронизированы" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 5. Формы записи апстрима, которые встречаются в поле ---------------------
+out=$(run "$Y_FORMS")
+case "$out" in
+    *'работать не будет'*) bad "[::1]:53 / udp:// / [/domain/] не распознаны локальными: [$out]" ;;
+    *'dns-proxy прошивки'*) ok "IPv6, схема udp:// и доменный селектор разобраны" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 6. Локальный, но ЧУЖОЙ резолвер — не наш случай --------------------------
+# 127.0.0.1:5353 — это dnscrypt-proxy или stubby, ip host они не применяют.
+# Ослабить проверку до «любой loopback» значило бы заменить одну ложь другой.
+out=$(run "$Y_OTHER_LOCAL")
+case "$out" in
+    *'НЕ синхронизированы'*) ok "чужой локальный резолвер за прошивочный прокси не выдаётся" ;;
+    *) bad "127.0.0.1:5353 ошибочно принят за dns-proxy прошивки: [$out]" ;;
+esac
+
+# --- 7. Протухшие rewrites сильнее апстрима — это поломка, а не «норма» -------
+# Без этой проверки правка, глушащая ложную тревогу, открыла бы ложное «всё
+# хорошо»: rewrites применяются ДО апстрима, и клиент получит адрес из них.
+out=$(run "$Y_STALE")
+case "$out" in
+    *'норма'*) bad "протухшая запись в rewrites объявлена нормой: [$out]" ;;
+    *'расходятся с ip host'*) ok "rewrites с чужим адресом при локальном апстриме — диагноз" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 8. Лишняя устаревшая запись поверх полного набора ------------------------
+out=$(run "$Y_SYNCED_PLUS_STALE")
+case "$out" in
+    *'— синхронизированы'*) bad "лишняя устаревшая запись не замечена: [$out]" ;;
+    *'расходятся с ip host'*) ok "устаревшая запись рядом с верными не теряется" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 9. Записей ip host нет — сверять нечего ----------------------------------
+out=$(run "$Y_LOCAL" "")
+case "$out" in
+    *'сверять нечего'*) ok "пустой ip host не объявляется поломкой" ;;
+    *) bad "пустой ip host разобран неверно: [$out]" ;;
+esac
+
+printf '\nPASSED: %s\nFAILED: %s\n' "$PASS" "$FAIL"
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
## Что не так

`print_agh` считает наши пины только в `rewrites:` файла `AdGuardHome.yaml` и при
нехватке выносит приговор:

```
AdGuardHome       : работает, наши записи в rewrites: 0/18 — НЕ синхронизированы:
                    AGH отвечает клиентам мимо ip host, обход Instagram/WhatsApp работать не будет
```

Для схемы, описанной в комментарии над функцией — «AGH забрал 53-й порт, dns-proxy
прошивки отключён, наружу AGH ходит сам» — это верно.

Но есть вторая распространённая схема: **AGH стоит перед прошивочным прокси**.
Слушает свой порт (обычно 5300), клиентов заворачивает `REDIRECT` в firewall, а
`upstream_dns` у него — `127.0.0.1:53`, то есть тот самый ndnproxy. Тогда `ip host`
применяется ниже по цепочке и доезжает до клиента ровно так же, как без AGH.
Рефрешер в `rewrites` не пишет и не должен (в его шапке речь только про `ip host`),
поэтому счёт `0/N` и крик получает **каждый** пользователь с такой схемой — на
полностью исправном роутере.

Цена ложной тревоги здесь не нулевая: по ней идут чинить то, что не сломано, и
вбивают пины в `rewrites` руками. Назавтра рефрешер меняет адреса (у меня сегодня в
04:00 обновились 4 хоста из 12), а копия в `rewrites` остаётся вчерашней — и, так
как rewrites сильнее апстрима, начинает **перебивать** свежие `ip host`. То есть
«починка» по этой строке ломает обход по-настоящему.

## Чем проверено

Keenetic Ultra KN-1812, r-82.2 + p-82.9, AdGuardHome 0.107.79, AGH на 5300,
`upstream_dns: [127.0.0.1:53]`, `rewrites: []`.

Сырой DNS-запрос по TCP, без участия резолвера системы:

| куда | ответ на `www.instagram.com` | TTL |
|---|---|---|
| `127.0.0.1:5300` (AGH) | `57.144.244.34` | 594 |
| `127.0.0.1:53` (ndnproxy) | `57.144.244.34` | 600 |

`57.144.244.34` — это ровно запись `ip host`. Меньший TTL у AGH показывает, что
ответ пришёл сверху вниз по цепочке и лежит у него в кэше, а не выдуман.

Что на 5300 отвечает действительно AGH, а не что-то другое, показывает
дискриминатор: `ad.doubleclick.net` там режется в `0.0.0.0`, а на 53 приходит
нормальный ответ.

## Что в правке

**1. Приговор зависит и от `upstream_dns`** — из того же yaml, который функция уже
открыла. Ни одного сетевого запроса не добавлено.

- все апстримы ведут в прошивочный прокси → справочная строка вместо тревоги:
  `в rewrites 0/18 — и это норма: апстрим 127.0.0.1:53 ведёт в dns-proxy прошивки, ip host применяется там`
- часть апстримов внешняя → `обход Instagram/WhatsApp будет работать через раз`
  (при `load_balance` пины применяются не на каждом запросе)
- локальных нет → **прежний громкий диагноз без изменений**
- `rewrites` заполнены пинами → прежнее «синхронизированы»

Разбираются формы, которыми апстрим записывают в поле: `127.0.0.1`, `127.0.0.1:53`,
`[::1]:53`, `udp://`, доменный селектор `[/domain/]127.0.0.1:53` и вынесенный
`upstream_dns_file`. Чужой локальный резолвер (`127.0.0.1:5353` — dnscrypt-proxy,
stubby) за прошивочный прокси намеренно **не** выдаётся: `ip host` он не применяет,
и ослабить проверку до «любой loopback» значило бы заменить одну ложь другой.

**2. Заодно закрыт обратный случай, который сам этот патч иначе бы открыл.**
Rewrites применяются ДО апстрима: если по нашим доменам там лежат чужие адреса, AGH
ответит ими, никого не спрашивая, и «локальный апстрим» перестаёт что-либо
гарантировать. Это ровно то состояние, в которое приходит человек, «починивший»
роутер по старой формулировке строки. Такие расхождения теперь считаются и
называются вслух:

```
AdGuardHome       : работает, в rewrites 2 записей по нашим доменам расходятся с ip host:
                    rewrites сильнее апстрима, клиент получит их адреса — обход сломается
```

Данные для счёта функция и так уже собирала, новых источников не появилось.

## Тест

`tests/test_diag_agh_upstream.sh` — 10 проверок, исполняет настоящие функции из
`files/z2k-diag.sh` с подставными `ndmc` и `AdGuardHome.yaml`. Отдельными пунктами
сторожит, что настоящий диагноз (AGH с внешними апстримами) не потерялся и что
протухшая запись в `rewrites` не выдаётся за норму.

```
PASSED: 10
FAILED: 0
```

Прогнано под bash и под BusyBox ash **на самом роутере** (`sh -n` там же чистый),
плюс все существующие наборы `test_diag_*` и `test_dns_check` — зелёные.

До и после на живом конфиге:

```
БЫЛО:  работает, наши записи в rewrites: 0/18 — НЕ синхронизированы: AGH отвечает
       клиентам мимо ip host, обход Instagram/WhatsApp работать не будет
СТАЛО: работает, в rewrites 0/18 — и это норма: апстрим 127.0.0.1:53 ведёт в
       dns-proxy прошивки, ip host применяется там
```
