### PR TITLE
fix(diag): AGH перед прошивочным прокси — это не рассинхрон

### DIFF
--- a/files/z2k-diag.sh
+++ b/files/z2k-diag.sh
@@ -1603,9 +1603,11 @@ print_insta_pins() {
 # Ведёт ли апстрим AGH обратно в dns-proxy прошивки. Петля на 53-й порт здесь
 # не ошибка конфигурации, а штатная схема: именно через неё доезжает `ip host`.
 # Разобрать надо все формы, которыми это записывают: 127.0.0.1, 127.0.0.1:53,
-# [::1]:53, udp://127.0.0.1:53 и доменный селектор AGH `[/domain/]127.0.0.1:53`.
+# [::1]:53, udp://127.0.0.1:53, доменный селектор AGH `[/domain/]127.0.0.1:53`
+# и собственный LAN-адрес роутера: на той же схеме он ведёт туда же, куда
+# и петля, но до этой правки считался внешним.
 agh_upstream_is_local() {
-    local u="$1" host port
+    local u="$1" lan="$2" host port
     case "$u" in
         \[/*\]*) u="${u#*\]}" ;;
     esac
@@ -1624,11 +1626,14 @@ agh_upstream_is_local() {
     case "$host" in
         127.*|::1|0:0:0:0:0:0:0:1|localhost) return 0 ;;
     esac
+    # Собственный адрес роутера в домашней сети ведёт в тот же прошивочный
+    # прокси, что и петля: на схеме «AGH перед dns-proxy» это одно и то же.
+    [ -n "$lan" ] && [ "$host" = "$lan" ] && return 0
     return 1
 }
 
 print_agh() {
-    local y c hosts pinned inagh cmp n_pin n_hit n_bad state ups upf u n_up n_uploc uploc
+    local y c hosts pinned inagh cmp n_pin n_hit n_bad state ups upf u n_up n_uploc uploc lan
     y=""
     for c in "${Z2K_AGH_YAML:-}" /opt/etc/AdGuardHome/AdGuardHome.yaml \
              /opt/AdGuardHome/AdGuardHome.yaml /opt/var/AdGuardHome/AdGuardHome.yaml \
@@ -1685,7 +1690,22 @@ print_agh() {
         function unq(s) { gsub(/"/, "", s); gsub(Q, "", s); return s }
         BEGIN { Q = sprintf("%c", 39)
                 KRX = "^[ \t]*[\"" Q "]?upstream_dns[\"" Q "]?[ \t]*:" }
-        !inb && $0 ~ KRX { inb = 1; kin = match($0, /[^ \t]/) - 1; next }
+        !inb && $0 ~ KRX {
+            kin = match($0, /[^ \t]/) - 1
+            match($0, KRX)
+            hv = trim(substr($0, RSTART + RLENGTH))
+            sub(/[ \t]+#.*$/, "", hv)
+            if (hv == "" || substr(hv, 1, 1) == "#") { inb = 1; next }
+            # Значение на той же строке: inline-массив [a, b] или скаляр.
+            # Сам AGH пишет блочный стиль, но правленные руками конфиги —
+            # ровно та аудитория, ради которой эта строка и переписывалась.
+            if (substr(hv, 1, 1) == "[") {
+                sub(/^\[/, "", hv); sub(/\]$/, "", hv)
+                m = split(hv, arr, ",")
+                for (j = 1; j <= m; j++) { w = unq(trim(arr[j])); if (w != "") print w }
+            } else { w = unq(hv); if (w != "") print w }
+            next
+        }
         inb {
             t = trim($0)
             if (t == "" || substr(t, 1, 1) == "#") next
@@ -1704,10 +1724,14 @@ print_agh() {
         ups="$ups
 $(sed 's/#.*//' "$upf" 2>/dev/null)"
     fi
+    # LAN-адрес берём один раз: get_lan_ip дёргает `ip route`, а при неудаче
+    # возвращает адрес с пояснением в скобках — нам нужно только первое слово.
+    lan="${Z2K_LAN_IP:-$(get_lan_ip)}"
+    lan="${lan%% *}"
     n_up=0; n_uploc=0; uploc=""
     for u in $ups; do
         n_up=$((n_up + 1))
-        if agh_upstream_is_local "$u"; then
+        if agh_upstream_is_local "$u" "$lan"; then
             n_uploc=$((n_uploc + 1))
             [ -n "$uploc" ] || uploc="$u"
         fi

--- a/files/z2k-diag.sh
+++ b/files/z2k-diag.sh
@@ -1568,15 +1568,67 @@ print_insta_pins() {
     fi
 }
 
-# AdGuard Home. Если он стоит, 53-й порт держит он, а встроенный dns-proxy
-# прошивки штатно отключается — и записи `ip host`, на которых держится обход
-# Instagram и веб-WhatsApp, не спрашивает НИКТО: они целы и бесполезны, клиент
-# получает подменённый провайдером адрес. Снаружи это неотличимо от «обход не
-# работает», в логах z2k при этом ровно ничего. Разбор такого случая у живого
-# пользователя занял час именно потому, что в сводке не было видно ни AGH, ни
-# того, что наши пины перекрыты.
+# AdGuard Home. Он перехватывает DNS у клиентов, а записи `ip host`, на которых
+# держится обход Instagram и веб-WhatsApp, применяет dns-proxy прошивки. Что из
+# этого выйдет — зависит от того, где именно стоит AGH:
+#
+#   1. AGH забрал 53-й порт, dns-proxy прошивки штатно отключён, наружу AGH
+#      ходит сам. Тогда `ip host` не спрашивает НИКТО: записи целы и бесполезны,
+#      клиент получает подменённый провайдером адрес. Снаружи это неотличимо от
+#      «обход не работает», в логах z2k при этом ровно ничего. Разбор такого
+#      случая у живого пользователя занял час именно потому, что в сводке не
+#      было видно ни AGH, ни того, что наши пины перекрыты.
+#
+#   2. AGH стоит ПЕРЕД прошивочным прокси: слушает свой порт (обычно 5300, а
+#      клиентов заворачивает REDIRECT в firewall), а `upstream_dns` у него —
+#      127.0.0.1:53, то есть тот самый dns-proxy. Пины применяются ниже по
+#      цепочке и доезжают до клиента ровно так же, как без AGH.
+#
+# ЧТО БЫЛО. Считались только записи в `rewrites:`, и во второй схеме сводка
+# объявляла рабочему роутеру «обход Instagram/WhatsApp работать не будет».
+# Рефрешер в rewrites ничего не пишет и не должен (см. шапку
+# z2k-insta-ip-refresh.sh — он правит `ip host`), поэтому счёт `0/N` и крик
+# получал КАЖДЫЙ пользователь с такой схемой, независимо от того, работает у
+# него обход или нет. Проверено пакетом на живом роутере: ответ AGH на
+# www.instagram.com равен записи `ip host`, а TTL в нём на несколько секунд
+# меньше — это его кэш ответа прошивочного прокси.
+#
+# Ложная тревога в диагностике дороже отсутствующей строки: по ней идут чинить
+# то, что не сломано, и добавляют в AGH статические rewrites, которые назавтра
+# протухнут и начнут перебивать свежие `ip host`. Поэтому приговор зависит и от
+# того, остался ли прошивочный прокси в цепочке, — это видно по `upstream_dns`
+# в том же yaml, который уже открыт. А сама та починка — протухшие rewrites поверх
+# свежих `ip host` — теперь ловится отдельной строкой: см. счёт расхождений ниже.
+
+# Ведёт ли апстрим AGH обратно в dns-proxy прошивки. Петля на 53-й порт здесь
+# не ошибка конфигурации, а штатная схема: именно через неё доезжает `ip host`.
+# Разобрать надо все формы, которыми это записывают: 127.0.0.1, 127.0.0.1:53,
+# [::1]:53, udp://127.0.0.1:53 и доменный селектор AGH `[/domain/]127.0.0.1:53`.
+agh_upstream_is_local() {
+    local u="$1" host port
+    case "$u" in
+        \[/*\]*) u="${u#*\]}" ;;
+    esac
+    case "$u" in
+        udp://*|tcp://*) u="${u#*://}" ;;
+        *://*) return 1 ;;
+    esac
+    case "$u" in
+        \[*\]:*) host="${u%%\]*}"; host="${host#\[}"; port="${u##*\]:}" ;;
+        \[*\])   host="${u#\[}"; host="${host%\]}"; port=53 ;;
+        *:*:*)   host="$u"; port=53 ;;
+        *:*)     host="${u%:*}"; port="${u##*:}" ;;
+        *)       host="$u"; port=53 ;;
+    esac
+    [ "$port" = 53 ] || return 1
+    case "$host" in
+        127.*|::1|0:0:0:0:0:0:0:1|localhost) return 0 ;;
+    esac
+    return 1
+}
+
 print_agh() {
-    local y c hosts pinned inagh cmp n_pin n_hit state
+    local y c hosts pinned inagh cmp n_pin n_hit n_bad state ups upf u n_up n_uploc uploc
     y=""
     for c in "${Z2K_AGH_YAML:-}" /opt/etc/AdGuardHome/AdGuardHome.yaml \
              /opt/AdGuardHome/AdGuardHome.yaml /opt/var/AdGuardHome/AdGuardHome.yaml \
@@ -1625,17 +1677,69 @@ print_agh() {
             else if (k == "answer") a = v
             if (d != "" && a != "" && (d in own)) { print d "\t" a; d = "" }
         }' "$y" 2>/dev/null)
+    # Апстримы — из того же файла, который уже открыт. Ни одного сетевого
+    # запроса: сводку гоняют и на роутере без интернета, и она обязана
+    # оставаться быстрой и одинаковой.
+    ups=$(awk '
+        function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t\r]+$/, "", s); return s }
+        function unq(s) { gsub(/"/, "", s); gsub(Q, "", s); return s }
+        BEGIN { Q = sprintf("%c", 39)
+                KRX = "^[ \t]*[\"" Q "]?upstream_dns[\"" Q "]?[ \t]*:" }
+        !inb && $0 ~ KRX { inb = 1; kin = match($0, /[^ \t]/) - 1; next }
+        inb {
+            t = trim($0)
+            if (t == "" || substr(t, 1, 1) == "#") next
+            cur = match($0, /[^ \t]/) - 1
+            if (cur < kin || (cur == kin && substr(t, 1, 1) != "-")) { inb = 0; next }
+            if (substr(t, 1, 1) != "-") next
+            v = unq(trim(substr(t, 2)))
+            if (v != "") print v
+        }' "$y" 2>/dev/null)
+    # upstream_dns_file: у части людей список апстримов вынесен в отдельный
+    # файл, и без него схема с прошивочным прокси выглядела бы как «апстримов
+    # нет» — то есть снова ложная тревога.
+    upf=$(sed -n 's/^[[:space:]]*upstream_dns_file[[:space:]]*:[[:space:]]*//p' "$y" 2>/dev/null \
+          | head -1 | tr -d "\"' 	")
+    if [ -n "$upf" ] && [ -r "$upf" ]; then
+        ups="$ups
+$(sed 's/#.*//' "$upf" 2>/dev/null)"
+    fi
+    n_up=0; n_uploc=0; uploc=""
+    for u in $ups; do
+        n_up=$((n_up + 1))
+        if agh_upstream_is_local "$u"; then
+            n_uploc=$((n_uploc + 1))
+            [ -n "$uploc" ] || uploc="$u"
+        fi
+    done
+    # Расхождение считаем отдельно: rewrites СИЛЬНЕЕ апстрима — AGH отвечает из
+    # них, никого не спрашивая. Поэтому запись по нашему домену с чужим адресом
+    # опаснее пустых rewrites: пины рефрешер обновляет каждую ночь, а вбитая
+    # руками копия остаётся с адресами прошлой недели и перебивает свежий
+    # `ip host`. Именно так «чинят» по старой формулировке этой же строки —
+    # случай не гипотетический.
     cmp=$( { printf '%s\n' "$pinned" | sed 's/^/P /'
              printf '%s\n' "$inagh"  | sed 's/^/A /'; } \
            | awk '$1 == "P" && NF == 3 { p[$2 " " $3] = 1; np++ }
                   $1 == "A" && NF == 3 { a[$2 " " $3] = 1 }
-                  END { for (k in p) if (k in a) h++; printf "%d %d", np + 0, h + 0 }')
-    n_pin=${cmp%% *}; n_hit=${cmp##* }
+                  END { for (k in p) if (k in a) h++
+                        for (k in a) if (!(k in p)) x++
+                        printf "%d %d %d", np + 0, h + 0, x + 0 }')
+    n_pin=${cmp%% *}; n_hit=${cmp#* }; n_bad=${n_hit#* }; n_hit=${n_hit%% *}
     if [ "$n_pin" = 0 ]; then
         printf 'AdGuardHome       : %s, наших ip host нет — сверять нечего\n' "$state"
+    elif [ "$n_bad" -gt 0 ]; then
+        printf 'AdGuardHome       : %s, в rewrites %s записей по нашим доменам расходятся с ip host: rewrites сильнее апстрима, клиент получит их адреса — обход Instagram/WhatsApp сломается\n' \
+            "$state" "$n_bad"
     elif [ "$n_hit" = "$n_pin" ]; then
         printf 'AdGuardHome       : %s, наши записи в rewrites: %s/%s — синхронизированы\n' \
             "$state" "$n_hit" "$n_pin"
+    elif [ "$n_up" -gt 0 ] && [ "$n_uploc" = "$n_up" ]; then
+        printf 'AdGuardHome       : %s, в rewrites %s/%s — и это норма: апстрим %s ведёт в dns-proxy прошивки, ip host применяется там\n' \
+            "$state" "$n_hit" "$n_pin" "$uploc"
+    elif [ "$n_uploc" -gt 0 ]; then
+        printf 'AdGuardHome       : %s, в rewrites %s/%s, а в dns-proxy прошивки ведут %s апстрима из %s: на остальных запросах ip host не применяется — обход Instagram/WhatsApp будет работать через раз\n' \
+            "$state" "$n_hit" "$n_pin" "$n_uploc" "$n_up"
     else
         printf 'AdGuardHome       : %s, наши записи в rewrites: %s/%s — НЕ синхронизированы: AGH отвечает клиентам мимо ip host, обход Instagram/WhatsApp работать не будет\n' \
             "$state" "$n_hit" "$n_pin"

--- a/tests/test_diag_agh_upstream.sh
+++ b/tests/test_diag_agh_upstream.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+# tests/test_diag_agh_upstream.sh — приговор про AdGuard Home обязан учитывать,
+# остался ли dns-proxy прошивки в цепочке.
+#
+# ЧТО БЫЛО. Строка считала только записи в `rewrites:` файла AdGuardHome.yaml и
+# при нехватке объявляла: «AGH отвечает клиентам мимо ip host, обход
+# Instagram/WhatsApp работать не будет». Для схемы «AGH забрал 53-й порт и ходит
+# наружу сам» это верно. Но у части людей AGH стоит ПЕРЕД прошивочным прокси:
+# слушает 5300, клиентов заворачивает REDIRECT, а `upstream_dns` — 127.0.0.1:53.
+# Там пины применяются ниже по цепочке и доезжают до клиента, а рефрешер в
+# rewrites не пишет и не должен — значит счёт `0/N` и крик получал КАЖДЫЙ такой
+# пользователь на рабочем роутере. Проверено пакетом на живом роутере: ответ AGH
+# на www.instagram.com равен записи `ip host`, TTL на несколько секунд меньше —
+# кэш ответа прошивочного прокси.
+#
+# Проверяется ИСПОЛНЕНИЕМ настоящих функций из files/z2k-diag.sh с подставными
+# ndmc и AdGuardHome.yaml.
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '[PASS] %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '[FAIL] %s\n' "$1"; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SB=$(mktemp -d) || exit 1
+trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB/bin"
+
+cat > "$SB/bin/ndmc" <<'STUB'
+#!/bin/sh
+cat "$NDM_CONF" 2>/dev/null
+STUB
+# Состояние AGH к приговору отношения не имеет, но пусть оно будет одинаковым
+# на машине разработчика и в CI — иначе набор зависит от того, что там запущено.
+cat > "$SB/bin/pidof" <<'STUB'
+#!/bin/sh
+exit 1
+STUB
+chmod +x "$SB/bin/ndmc" "$SB/bin/pidof"
+
+# Функции берём настоящие: тест сторожит поведение сводки, а не свою копию кода.
+for fn in insta_pinned agh_upstream_is_local print_agh; do
+    awk -v f="$fn" 'index($0, f "() {") == 1, /^\}/' "$ROOT/files/z2k-diag.sh" >> "$SB/blk.sh"
+    printf '\n' >> "$SB/blk.sh"
+done
+printf 'print_agh\n' >> "$SB/blk.sh"
+for fn in insta_pinned agh_upstream_is_local print_agh; do
+    grep -q "^${fn}() {" "$SB/blk.sh" || {
+        bad "не нашёл $fn в z2k-diag.sh — проверка ослепла"
+        printf '\nPASSED: %s\nFAILED: %s\n' "$PASS" "$FAIL"; exit 1; }
+done
+
+printf 'HOSTS="a.test b.test"\n' > "$SB/z2k-insta-ip-refresh.sh"
+PINS='ip host a.test 1.2.3.4
+ip host b.test 5.6.7.8'
+
+run() {  # run <yaml> [running-config]
+    printf '%s\n' "$1" > "$SB/agh.yaml"
+    printf '%s\n' "${2-$PINS}" > "$SB/ndm.conf"
+    env PATH="$SB/bin:$PATH" ZAPRET2_DIR="$SB" Z2K_AGH_YAML="$SB/agh.yaml" \
+        NDM_CONF="$SB/ndm.conf" "${Z2K_TEST_SH:-sh}" "$SB/blk.sh" 2>/dev/null
+}
+
+Y_LOCAL='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_EXTERNAL='dns:
+  upstream_dns:
+    - tls://1.1.1.1
+    - https://dns.google/dns-query
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_MIXED='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+    - 8.8.8.8
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_SYNCED='dns:
+  upstream_dns:
+    - tls://1.1.1.1
+  upstream_dns_file: ""
+filtering:
+  rewrites:
+    - domain: a.test
+      answer: 1.2.3.4
+    - domain: b.test
+      answer: 5.6.7.8'
+
+Y_FORMS='dns:
+  upstream_dns:
+    - "[::1]:53"
+    - udp://127.0.0.1
+    - "[/instagram.com/]127.0.0.1:53"
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_OTHER_LOCAL='dns:
+  upstream_dns:
+    - 127.0.0.1:5353
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+# Протухшая копия пинов в rewrites — то, что делают, «починив» роутер по старой
+# формулировке этой же строки. Апстрим при этом локальный, то есть без счёта
+# расхождений сводка сказала бы «и это норма».
+Y_STALE='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites:
+    - domain: a.test
+      answer: 9.9.9.9'
+
+# Все пины на месте, но рядом лежит лишняя устаревшая запись: AGH отдаст оба
+# адреса, и половина соединений уедет в мёртвый.
+Y_SYNCED_PLUS_STALE='dns:
+  upstream_dns:
+    - 127.0.0.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites:
+    - domain: a.test
+      answer: 1.2.3.4
+    - domain: a.test
+      answer: 9.9.9.9
+    - domain: b.test
+      answer: 5.6.7.8'
+
+# --- 1. Главный случай: AGH перед прошивочным прокси --------------------------
+# Это и есть исходный дефект: рабочему роутеру сообщалось «работать не будет».
+out=$(run "$Y_LOCAL")
+case "$out" in
+    *'работать не будет'*) bad "ложная тревога: апстрим 127.0.0.1:53, пины доезжают: [$out]" ;;
+    *'dns-proxy прошивки'*) ok "петля на 53-й порт распознана как штатная схема" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+case "$out" in
+    *'127.0.0.1:53'*) ok "апстрим показан значением, а не пересказан" ;;
+    *) bad "апстрим не показан: [$out]" ;;
+esac
+
+# --- 2. Настоящий диагноз сохранён --------------------------------------------
+# Ради этого случая строка и добавлялась: AGH ходит наружу сам, ip host мёртв.
+out=$(run "$Y_EXTERNAL")
+case "$out" in
+    *'НЕ синхронизированы'*) ok "AGH с внешними апстримами по-прежнему диагноз" ;;
+    *) bad "главный диагноз потерян: [$out]" ;;
+esac
+
+# --- 3. Часть апстримов внешняя — это не «всё хорошо» -------------------------
+out=$(run "$Y_MIXED")
+case "$out" in
+    *'через раз'*) ok "смешанные апстримы названы своим именем" ;;
+    *) bad "смешанные апстримы разобраны неверно: [$out]" ;;
+esac
+
+# --- 4. Пины продублированы в rewrites — прежний зелёный вердикт --------------
+out=$(run "$Y_SYNCED")
+case "$out" in
+    *'НЕ синхронизированы'*) bad "заполненные rewrites объявлены рассинхроном: [$out]" ;;
+    *'— синхронизированы'*) ok "заполненные rewrites по-прежнему синхронизированы" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 5. Формы записи апстрима, которые встречаются в поле ---------------------
+out=$(run "$Y_FORMS")
+case "$out" in
+    *'работать не будет'*) bad "[::1]:53 / udp:// / [/domain/] не распознаны локальными: [$out]" ;;
+    *'dns-proxy прошивки'*) ok "IPv6, схема udp:// и доменный селектор разобраны" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 6. Локальный, но ЧУЖОЙ резолвер — не наш случай --------------------------
+# 127.0.0.1:5353 — это dnscrypt-proxy или stubby, ip host они не применяют.
+# Ослабить проверку до «любой loopback» значило бы заменить одну ложь другой.
+out=$(run "$Y_OTHER_LOCAL")
+case "$out" in
+    *'НЕ синхронизированы'*) ok "чужой локальный резолвер за прошивочный прокси не выдаётся" ;;
+    *) bad "127.0.0.1:5353 ошибочно принят за dns-proxy прошивки: [$out]" ;;
+esac
+
+# --- 7. Протухшие rewrites сильнее апстрима — это поломка, а не «норма» -------
+# Без этой проверки правка, глушащая ложную тревогу, открыла бы ложное «всё
+# хорошо»: rewrites применяются ДО апстрима, и клиент получит адрес из них.
+out=$(run "$Y_STALE")
+case "$out" in
+    *'норма'*) bad "протухшая запись в rewrites объявлена нормой: [$out]" ;;
+    *'расходятся с ip host'*) ok "rewrites с чужим адресом при локальном апстриме — диагноз" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 8. Лишняя устаревшая запись поверх полного набора ------------------------
+out=$(run "$Y_SYNCED_PLUS_STALE")
+case "$out" in
+    *'— синхронизированы'*) bad "лишняя устаревшая запись не замечена: [$out]" ;;
+    *'расходятся с ip host'*) ok "устаревшая запись рядом с верными не теряется" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 9. Записей ip host нет — сверять нечего ----------------------------------
+out=$(run "$Y_LOCAL" "")
+case "$out" in
+    *'сверять нечего'*) ok "пустой ip host не объявляется поломкой" ;;
+    *) bad "пустой ip host разобран неверно: [$out]" ;;
+esac
+
+printf '\nPASSED: %s\nFAILED: %s\n' "$PASS" "$FAIL"
+[ "$FAIL" = 0 ]

--- a/tests/test_diag_agh_upstream.sh
+++ b/tests/test_diag_agh_upstream.sh
@@ -34,15 +34,29 @@ cat > "$SB/bin/pidof" <<'STUB'
 #!/bin/sh
 exit 1
 STUB
-chmod +x "$SB/bin/ndmc" "$SB/bin/pidof"
+# LAN-адрес роутера берётся настоящим get_lan_ip, а не подставляется переменной:
+# проверять надо ту же цепочку, по которой сводка печатает строку «LAN IP».
+cat > "$SB/bin/ip" <<'STUB'
+#!/bin/sh
+case "$*" in
+    *"route get"*) [ -n "$IP_ROUTE_GET" ] && printf '%s\n' "$IP_ROUTE_GET" ;;
+    *"addr show"*) [ -n "$IP_ADDR" ] && printf '%s\n' "$IP_ADDR" ;;
+esac
+exit 0
+STUB
+chmod +x "$SB/bin/ndmc" "$SB/bin/pidof" "$SB/bin/ip"
+
+DEF_ROUTE='1.1.1.1 via 192.168.100.1 dev eth3 src 192.168.100.10'
+DEF_ADDR='2: br0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
+    inet 192.168.1.1/24 brd 192.168.1.255 scope global br0'
 
 # Функции берём настоящие: тест сторожит поведение сводки, а не свою копию кода.
-for fn in insta_pinned agh_upstream_is_local print_agh; do
+for fn in get_lan_ip insta_pinned agh_upstream_is_local print_agh; do
     awk -v f="$fn" 'index($0, f "() {") == 1, /^\}/' "$ROOT/files/z2k-diag.sh" >> "$SB/blk.sh"
     printf '\n' >> "$SB/blk.sh"
 done
 printf 'print_agh\n' >> "$SB/blk.sh"
-for fn in insta_pinned agh_upstream_is_local print_agh; do
+for fn in get_lan_ip insta_pinned agh_upstream_is_local print_agh; do
     grep -q "^${fn}() {" "$SB/blk.sh" || {
         bad "не нашёл $fn в z2k-diag.sh — проверка ослепла"
         printf '\nPASSED: %s\nFAILED: %s\n' "$PASS" "$FAIL"; exit 1; }
@@ -56,7 +70,9 @@ run() {  # run <yaml> [running-config]
     printf '%s\n' "$1" > "$SB/agh.yaml"
     printf '%s\n' "${2-$PINS}" > "$SB/ndm.conf"
     env PATH="$SB/bin:$PATH" ZAPRET2_DIR="$SB" Z2K_AGH_YAML="$SB/agh.yaml" \
-        NDM_CONF="$SB/ndm.conf" "${Z2K_TEST_SH:-sh}" "$SB/blk.sh" 2>/dev/null
+        NDM_CONF="$SB/ndm.conf" \
+        IP_ROUTE_GET="${IP_ROUTE_GET-$DEF_ROUTE}" IP_ADDR="${IP_ADDR-$DEF_ADDR}" \
+        "${Z2K_TEST_SH:-sh}" "$SB/blk.sh" 2>/dev/null
 }
 
 Y_LOCAL='dns:
@@ -138,6 +154,41 @@ filtering:
 
 # --- 1. Главный случай: AGH перед прошивочным прокси --------------------------
 # Это и есть исходный дефект: рабочему роутеру сообщалось «работать не будет».
+# Значение на той же строке, что и ключ. AGH так не пишет, но правленые руками
+# конфиги — ровно та аудитория, ради которой строка и переписывалась.
+Y_INLINE='dns:
+  upstream_dns: [127.0.0.1:53]
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_SCALAR='dns:
+  upstream_dns: 127.0.0.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_INLINE_EXT='dns:
+  upstream_dns: [tls://1.1.1.1, 8.8.8.8]
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+# Собственный адрес роутера ведёт в тот же прошивочный прокси, что и петля.
+Y_LAN='dns:
+  upstream_dns:
+    - 192.168.1.1:53
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
+Y_LAN_OTHER_PORT='dns:
+  upstream_dns:
+    - 192.168.1.1:5353
+  upstream_dns_file: ""
+filtering:
+  rewrites: []'
+
 out=$(run "$Y_LOCAL")
 case "$out" in
     *'работать не будет'*) bad "ложная тревога: апстрим 127.0.0.1:53, пины доезжают: [$out]" ;;
@@ -207,7 +258,58 @@ case "$out" in
     *) bad "непонятный вывод: [$out]" ;;
 esac
 
-# --- 9. Записей ip host нет — сверять нечего ----------------------------------
+# --- 9. Значение на строке ключа: inline-массив ------------------------------
+# Разбор понимал только блочный список: ключ матчился, а значение с той же
+# строки уходило в next — и получалась прежняя ложная тревога.
+out=$(run "$Y_INLINE")
+case "$out" in
+    *'работать не будет'*) bad "inline-массив не разобран: [$out]" ;;
+    *'dns-proxy прошивки'*) ok "inline-массив [127.0.0.1:53] разобран" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 10. Значение на строке ключа: скаляр ------------------------------------
+out=$(run "$Y_SCALAR")
+case "$out" in
+    *'работать не будет'*) bad "скаляр не разобран: [$out]" ;;
+    *'dns-proxy прошивки'*) ok "скаляр upstream_dns: 127.0.0.1:53 разобран" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 11. Inline с внешними — настоящий диагноз не потерян --------------------
+out=$(run "$Y_INLINE_EXT")
+case "$out" in
+    *'НЕ синхронизированы'*) ok "inline с внешними апстримами по-прежнему диагноз" ;;
+    *) bad "inline с внешними разобран неверно: [$out]" ;;
+esac
+
+# --- 12. LAN-адрес роутера — тот же прошивочный прокси -----------------------
+out=$(run "$Y_LAN")
+case "$out" in
+    *'работать не будет'*) bad "192.168.1.1:53 объявлен внешним, хотя это сам роутер: [$out]" ;;
+    *'dns-proxy прошивки'*) ok "LAN-адрес роутера распознан через get_lan_ip" ;;
+    *) bad "непонятный вывод: [$out]" ;;
+esac
+
+# --- 13. LAN-адрес, но чужой порт — не наш случай ----------------------------
+out=$(run "$Y_LAN_OTHER_PORT")
+case "$out" in
+    *'НЕ синхронизированы'*) ok "192.168.1.1:5353 за прошивочный прокси не выдаётся" ;;
+    *) bad "чужой порт на адресе роутера принят за dns-proxy: [$out]" ;;
+esac
+
+# --- 14. LAN-адрес не определился — молча считаем внешним --------------------
+# get_lan_ip в этом случае отдаёт "unknown", и сравнение не должно совпасть
+# ни с чем: соврать «всё хорошо» здесь хуже, чем оставить прежний диагноз.
+IP_ADDR=""; IP_ROUTE_GET=""
+out=$(run "$Y_LAN")
+unset IP_ADDR IP_ROUTE_GET
+case "$out" in
+    *'НЕ синхронизированы'*) ok "без известного LAN-адреса апстрим считается внешним" ;;
+    *) bad "неизвестный LAN-адрес дал ложное «всё хорошо»: [$out]" ;;
+esac
+
+# --- 15. Записей ip host нет — сверять нечего ---------------------------------
 out=$(run "$Y_LOCAL" "")
 case "$out" in
     *'сверять нечего'*) ok "пустой ip host не объявляется поломкой" ;;


### PR DESCRIPTION
Перенос #50 в `z2k-staging`. Ветку пересобрал от неё же: клон укороченный,
общего предка у веток нет, поэтому перенёс коммит черри-пиком.

Содержание прежнее плюс два случая из вашего ревью.

## Что чинит правка

`print_agh` считал пины только в `rewrites:` и при нехватке печатал «AGH
отвечает клиентам мимо ip host, обход работать не будет». Для схемы «AGH
держит 53-й порт и ходит наружу сам» это верно. При схеме «AGH перед
прошивочным dns-proxy» (AGH на 5300, клиентов заворачивает REDIRECT,
`upstream_dns: 127.0.0.1:53`) пины применяет прокси ниже по цепочке, и клиент
их получает. Рефрешер в `rewrites` не пишет, поэтому счёт `0/N` и крик получал
каждый пользователь такой схемы.

Замерил на роутере сырым DNS-пакетом по TCP:

| порт | ответ на www.instagram.com | TTL |
|---|---|---|
| 5300 (AGH) | 57.144.244.34 | 594 |
| 53 (ndnproxy) | 57.144.244.34 | 600 |

Адрес совпадает с записью `ip host`, меньший TTL выдаёт кэш ответа прокси. Что
на 5300 отвечает именно AGH, показывает `ad.doubleclick.net`: там он режется в
0.0.0.0, а на 53 приходит обычный ответ.

Приговор теперь зависит и от `upstream_dns` из того же файла. Сетевых запросов
не добавилось.

Вторая ветка правки ловит обратный случай. Rewrites применяются до апстрима,
поэтому чужие адреса по нашим доменам перебивают `ip host`. В это состояние
приходит тот, кто «починил» роутер по старой формулировке: вбил пины руками,
назавтра рефрешер обновил адреса, копия осталась вчерашней.

## Правки по ревью

**1. Разбор понимал только блочный список.** Ключевая строка матчилась, `inb`
выставлялся, значение с той же строки уходило в `next`. Теперь остаток строки
после ключа разбирается сразу: inline-массив режется по запятой, скаляр берётся
как есть, пустое значение или комментарий отправляют в блочный режим. Хвостовой
комментарий после значения отбрасывается.

**2. LAN-адрес роутера считался внешним.** Беру его из `get_lan_ip`, той же
функции, которой сводка печатает строку `LAN IP`, и передаю в проверку вторым
аргументом. Вызываю один раз, хвост «(адрес наружу...)» отрезаю. При `unknown`
совпадения не будет.

## Тест

Было 10 проверок, стало 16. Добавил inline-массив, скаляр, inline с внешними
апстримами, LAN-адрес, LAN-адрес с чужим портом и случай «LAN-адрес не
определился». Адрес в тесте не подставляю переменной: его считает настоящий
`get_lan_ip` с подменённым `ip`, то есть набор сторожит ту же цепочку, по
которой печатается строка `LAN IP`.

Прогнал под bash и под BusyBox ash на самом роутере, `sh -n` там же чистый. 
Девять входных вариантов дают ожидаемые вердикты, включая три из вашего ревью.
Остальные наборы, читающие `files/z2k-diag.sh`, зелёные: 12 × `test_diag_*`, `test_dns_check`,
`test_daemon_failure_reason`, `test_silent_fallback_removed`.