### PR TITLE
feat(config): hostkey=z2k_hostkey_split — своя ячейка ротации для отдельных хостов rkn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,6 +709,7 @@ jobs:
           lua5.3 tests/test_alert_detector.lua
           lua5.3 tests/test_http_classifier.lua
           lua5.3 tests/test_quic_silence_detector.lua
+          lua5.3 tests/test_z2k_hostkey_split.lua
 
   mutation:
     name: Mutation Testing

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -37,6 +37,8 @@ globals = {
     "automate_failure_counter",
     -- z2k-modern-core.lua hostkey fn (returns "nohost" for IP/no-hostname flows)
     "z2k_nohost_key",
+    -- z2k-modern-core.lua hostkey fn (gives listed hosts their own rotation bucket)
+    "z2k_hostkey_split",
     -- z2k-state-persist.lua exported API table
     "z2k_state_persist",
     -- z2k-detectors.lua internal helper, top-level so earlier detector

--- a/files/lua/z2k-modern-core.lua
+++ b/files/lua/z2k-modern-core.lua
@@ -50,6 +50,40 @@ function z2k_nohost_key(desync)
     return "nohost"
 end
 
+-- Per-host rotation-bucket split for the circular rotator. Plug into bol-van's
+-- circular() via arg `hostkey=z2k_hostkey_split` (automate_host_record extension
+-- point, см. zapret-auto.lua), exactly like z2k_nohost_key above.
+--
+-- Problem: circular's stock standard_hostkey cuts the hostname to its
+-- registrable domain (arg nld=N, default 2) before keying rotation state, so
+-- updates.discord.com folds into discord.com and SHARES its autostate bucket —
+-- both rotate on one (pool,key) cell. When two siblings of the same registrable
+-- domain need DIFFERENT working legs — updates.discord.com is a Rust/rustls
+-- updater whose ~1.8 KB ClientHello a browser-tuned leg does not punch, while
+-- discord.com is Chromium — one bucket cannot satisfy both: the leg that unblocks
+-- one breaks the other.
+--
+-- z2k_hostkey_split gives each LISTED hostname its own bucket by skipping the nld
+-- cut for it (keyed on the full hostname), mirroring standard_hostkey's
+-- family_split |4/|6 suffix so bucket semantics are otherwise identical. Every
+-- hostname NOT listed keeps stock behavior via standard_hostkey — a no-op for the
+-- rest of the pool. Contract: tests/test_z2k_hostkey_split.lua.
+local Z2K_HOSTKEY_SPLIT = {
+    ["updates.discord.com"] = true,
+}
+function z2k_hostkey_split(desync)
+    local t = desync and desync.track
+    local h = t and t.hostname
+    if h and #h > 0 and not (t and t.hostname_is_ip) and Z2K_HOSTKEY_SPLIT[h] then
+        local arg = desync.arg or {}
+        if arg.family_split ~= "0" and desync.dis then
+            if desync.dis.ip6 then return h .. "|6" else return h .. "|4" end
+        end
+        return h
+    end
+    return standard_hostkey(desync)
+end
+
 local function z2k_num(v, fallback)
     local n = tonumber(v)
     if n == nil then return fallback end

--- a/lib/config_official.sh
+++ b/lib/config_official.sh
@@ -299,9 +299,48 @@ generate_nfqws2_opt_from_strategies() {
         printf '%s' "$out"
     }
 
+    # Разнесение ключа ротации для отдельных хостов rkn. Вешает
+    # hostkey=z2k_hostkey_split на circular-директиву, если генератор ключа ещё
+    # не задан. Функция (files/lua/z2k-modern-core.lua) отдаёт перечисленным в ней
+    # хостам (updates.discord.com — rustls-апдейтер, которому нужна не та нога, что
+    # браузерному discord.com) собственную ячейку ротации, а всем прочим —
+    # нетронутый сток standard_hostkey. Точечно только для rkn_tcp: это пул, куда
+    # попадает updates.discord.com. Ставится ПОСЛЕ nld2, но раньше doc_args/
+    # in_range — те сохраняют неизвестные им аргументы circular ($rest), поэтому
+    # hostkey= доедет до движка (проверяется в test_config_official.sh).
+    ensure_circular_hostkey_split() {
+        local input="$1"
+        local out="" token="" opts="" part="" has_hostkey=""
+        local old_ifs="$IFS"
+
+        set -f  # без глоба: токены могут нести *,?,[ ] из правленого Strategy.txt
+        for token in $input; do
+            case "$token" in
+                --lua-desync=circular:*)
+                    opts="${token#--lua-desync=circular:}"
+                    has_hostkey=""
+                    IFS=':'
+                    for part in $opts; do
+                        case "$part" in
+                            hostkey=*) has_hostkey="1" ;;
+                        esac
+                    done
+                    IFS="$old_ifs"
+                    [ -z "$has_hostkey" ] && token="${token}:hostkey=z2k_hostkey_split"
+                    ;;
+            esac
+            out="${out:+$out }$token"
+        done
+        set +f
+
+        IFS="$old_ifs"
+        printf '%s' "$out"
+    }
+
     youtube_tcp=$(ensure_circular_nld2 "$youtube_tcp")
     youtube_gv_tcp=$(ensure_circular_nld2 "$youtube_gv_tcp")
     rkn_tcp=$(ensure_circular_nld2 "$rkn_tcp")
+    rkn_tcp=$(ensure_circular_hostkey_split "$rkn_tcp")
     quic_udp=$(ensure_circular_nld2 "$quic_udp")
 
     # ── Окно счётчика провалов (`time=`) ─────────────────────────────────────

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -271,7 +271,8 @@ done
 if [ -n "$LUA_BIN" ]; then
     _lua_rc=0
     for _h in tests/test_tcp16_lua.lua tests/test_alert_detector.lua \
-              tests/test_http_classifier.lua tests/test_quic_silence_detector.lua; do
+              tests/test_http_classifier.lua tests/test_quic_silence_detector.lua \
+              tests/test_z2k_hostkey_split.lua; do
         "$LUA_BIN" "$_h" || _lua_rc=1
     done
     if [ "$_lua_rc" = "0" ]; then

--- a/tests/test_config_official.sh
+++ b/tests/test_config_official.sh
@@ -155,6 +155,69 @@ INPUT4="--lua-desync=circular:key=test"
 RESULT4=$(ensure_circular_nld2 "$INPUT4")
 assert_contains "nld2: adds nld=2 to minimal circular" "nld=2" "$RESULT4"
 
+# ==============================================================================
+# TEST: ensure_circular_hostkey_split (extracted inline from
+# generate_nfqws2_opt_from_strategies). Replicated here — it is a nested function.
+# Contract: append hostkey=z2k_hostkey_split to a circular token that has no key
+# generator yet; leave an explicit hostkey= untouched; never touch non-circular
+# tokens. The lua side (z2k_hostkey_split in files/lua/z2k-modern-core.lua) is
+# covered by tests/test_z2k_hostkey_split.lua. Ordering note: this runs after
+# ensure_circular_nld2 and before ensure_circular_doc_args/in_range, which keep
+# unknown circular args ($rest), so the appended hostkey= survives to the engine.
+# ==============================================================================
+
+ensure_circular_hostkey_split() {
+    local input="$1"
+    local out="" token="" opts="" part="" has_hostkey=""
+    local old_ifs="$IFS"
+
+    for token in $input; do
+        case "$token" in
+            --lua-desync=circular:*)
+                opts="${token#--lua-desync=circular:}"
+                has_hostkey=""
+                IFS=':'
+                for part in $opts; do
+                    case "$part" in
+                        hostkey=*) has_hostkey="1" ;;
+                    esac
+                done
+                IFS="$old_ifs"
+                [ -z "$has_hostkey" ] && token="${token}:hostkey=z2k_hostkey_split"
+                ;;
+        esac
+        out="${out:+$out }$token"
+    done
+
+    IFS="$old_ifs"
+    printf '%s' "$out"
+}
+
+printf "\n--- ensure_circular_hostkey_split ---\n"
+
+# Test: adds the split key generator to a circular token that has none
+HK_IN1="--filter-tcp=443 --lua-desync=circular:fails=3:time=60:key=rkn_tcp:nld=2 --lua-desync=fake:strategy=1"
+HK_R1=$(ensure_circular_hostkey_split "$HK_IN1")
+assert_contains "hostkey_split: adds hostkey=z2k_hostkey_split" "hostkey=z2k_hostkey_split" "$HK_R1"
+assert_contains "hostkey_split: preserves key=rkn_tcp" "key=rkn_tcp" "$HK_R1"
+assert_contains "hostkey_split: preserves nld=2" "nld=2" "$HK_R1"
+assert_contains "hostkey_split: preserves non-circular tokens" "--lua-desync=fake:strategy=1" "$HK_R1"
+
+# Test: idempotent — a second pass does not append a second hostkey
+HK_R1B=$(ensure_circular_hostkey_split "$HK_R1")
+assert_eq "hostkey_split: idempotent (no double-append)" "$HK_R1" "$HK_R1B"
+
+# Test: an explicit hostkey is left untouched (e.g. discord_udp's z2k_nohost_key)
+HK_IN2="--lua-desync=circular:fails=3:key=discord_udp:nld=2:hostkey=z2k_nohost_key --lua-desync=fake:strategy=1"
+HK_R2=$(ensure_circular_hostkey_split "$HK_IN2")
+assert_contains "hostkey_split: keeps existing z2k_nohost_key" "hostkey=z2k_nohost_key" "$HK_R2"
+assert_not_contains "hostkey_split: does not override an explicit hostkey" "z2k_hostkey_split" "$HK_R2"
+
+# Test: non-circular token unchanged
+HK_IN3="--lua-desync=fake:payload=tls_client_hello:dir=out"
+HK_R3=$(ensure_circular_hostkey_split "$HK_IN3")
+assert_eq "hostkey_split: non-circular token unchanged" "$HK_IN3" "$HK_R3"
+
 printf "\n--- Austerus mode removed (all_tcp443) ---\n"
 
 # Режим Austerusj снят 2026-08-04. Раньше здесь лежал тест, который ничего не
@@ -667,6 +730,23 @@ assert_contains     "ручной Strategy.txt: inseq=4096 поставлен"  
 assert_contains     "ручной Strategy.txt: retrans=3 поставлен"     "retrans=3"         "$_rkn_hand"
 _dups=$(printf '%s' "$_rkn_hand" | grep -o "retrans=" | wc -l | tr -d ' ')
 assert_eq "ручной Strategy.txt: retrans не задвоен" "1" "$_dups"
+
+# ── e2e: hostkey=z2k_hostkey_split доезжает до вывода реального генератора ────
+# Не инлайн-копию трансформа, а настоящий generate_nfqws2_opt_from_strategies:
+# ensure_circular_hostkey_split вешает hostkey= на rkn-circular, и он переживает
+# всю цепочку (nld2 → hostkey_split → doc_args → in_range → failure_detector),
+# т.к. каждый последующий трансформ либо сохраняет неизвестные аргументы circular,
+# либо не трогает сам токен. Разбор в комментарии у функции в config_official.sh.
+printf "\n--- e2e: hostkey_split в выводе генератора ---\n"
+OUT_HK=$(run_generator "hostkey-split" "" "_seed_tls_circulars")
+_rkn_hk=$(get_rkn_tcp_arm_line "$OUT_HK" | tr ' ' '\n' | grep -- '--lua-desync=circular:' | head -1)
+assert_contains "e2e: rkn-circular несёт hostkey=z2k_hostkey_split" "hostkey=z2k_hostkey_split" "$_rkn_hk"
+assert_contains "e2e: split на том же токене, что key=rkn_tcp" "key=rkn_tcp" "$_rkn_hk"
+_dups_hk=$(printf '%s' "$_rkn_hk" | grep -o "hostkey=" | wc -l | tr -d ' ')
+assert_eq "e2e: hostkey не задвоен" "1" "$_dups_hk"
+# Точечность: yt_tcp — чужой пул, split на него не вешается.
+_yt_hk=$(printf '%s\n' "$OUT_HK" | awk -f "$SCRIPT_DIR/tests/lib/nfqws2_flatten.awk" | grep -F "key=yt_tcp" | head -1 | tr ' ' '\n' | grep -- '--lua-desync=circular:' | head -1)
+assert_not_contains "e2e: yt_tcp не получает split (rkn-only)" "z2k_hostkey_split" "$_yt_hk"
 
 # NFQWS2_TCP_PKT_IN — окно входящих в пакетах — 10: детектору успеха нужно
 # inseq=4096 + пакет, десять — двойной запас; прежние 50 кормили сторож обрыва.

--- a/tests/test_z2k_hostkey_split.lua
+++ b/tests/test_z2k_hostkey_split.lua
@@ -1,0 +1,104 @@
+-- tests/test_z2k_hostkey_split.lua
+-- Unit tests for z2k_hostkey_split — the arg.hostkey generator that gives a
+-- listed hostname its OWN circular rotation bucket instead of folding it into
+-- its registrable domain (stock standard_hostkey nld cut). Motivating case:
+-- updates.discord.com (rustls updater) must not share discord.com's (Chromium)
+-- rotation cell, because a leg that punches one breaks the other. See
+-- files/lua/z2k-modern-core.lua and zapret-auto.lua automate_host_record
+-- (arg.hostkey extension point).
+
+local PASS, FAIL = 0, 0
+local function check(cond, msg)
+  if cond then
+    PASS = PASS + 1
+    print("[PASS] " .. msg)
+  else
+    FAIL = FAIL + 1
+    print("[FAIL] " .. msg)
+  end
+end
+
+-- runtime global stubs the module expects when loaded standalone
+function DLOG(...) end
+function DLOG_ERR(...) end
+
+-- Stub of zapret-auto.lua standard_hostkey: registrable-domain cut (nld=2) plus
+-- the family_split |4/|6 suffix, with the host_ip fallback collapsed to the
+-- sentinel "IP". Mirrors the real contract closely enough to prove that
+-- z2k_hostkey_split BYPASSES the cut for listed hosts and DELEGATES otherwise.
+function standard_hostkey(desync)
+  local t = desync and desync.track
+  local h = t and t.hostname
+  if not h or #h == 0 or (t and t.hostname_is_ip) then
+    return "IP"
+  end
+  local labels = {}
+  for lbl in string.gmatch(h, "[^.]+") do labels[#labels + 1] = lbl end
+  local n = #labels
+  local key = h
+  if n >= 2 then key = labels[n - 1] .. "." .. labels[n] end
+  local arg = desync and desync.arg or {}
+  if arg.family_split ~= "0" and desync and desync.dis then
+    key = key .. (desync.dis.ip6 and "|6" or "|4")
+  end
+  return key
+end
+
+dofile("files/lua/z2k-modern-core.lua")
+
+check(type(z2k_hostkey_split) == "function",
+      "z2k_hostkey_split defined after loading z2k-modern-core.lua")
+
+-- opts: is_ip, ip6, family_split
+local function mk(hostname, opts)
+  opts = opts or {}
+  return {
+    track = { hostname = hostname, hostname_is_ip = opts.is_ip },
+    dis   = { ip6 = opts.ip6 or false },
+    arg   = { family_split = opts.family_split },
+  }
+end
+
+-- 1. Listed host keeps its FULL name (no nld fold), with the ipv4 family suffix.
+check(z2k_hostkey_split(mk("updates.discord.com")) == "updates.discord.com|4",
+      "listed host -> own bucket 'updates.discord.com|4' (nld cut skipped)")
+
+-- 2. Family suffix tracks the flow's address family.
+check(z2k_hostkey_split(mk("updates.discord.com", { ip6 = true })) == "updates.discord.com|6",
+      "listed host over ipv6 -> 'updates.discord.com|6'")
+
+-- 3. family_split=0 drops the suffix, same as standard_hostkey.
+check(z2k_hostkey_split(mk("updates.discord.com", { family_split = "0" })) == "updates.discord.com",
+      "listed host with family_split=0 -> 'updates.discord.com' (no suffix)")
+
+-- 4. THE POINT: the listed host and its registrable domain land in DIFFERENT
+--    buckets. Stock behavior folds both to discord.com|4; the split keeps them
+--    apart, so updates.discord.com can rotate/freeze onto its own working leg.
+local k_updates = z2k_hostkey_split(mk("updates.discord.com"))
+local k_discord = z2k_hostkey_split(mk("discord.com"))
+check(k_updates ~= k_discord,
+      "sibling isolation: updates.discord.com and discord.com get DIFFERENT buckets")
+check(standard_hostkey(mk("updates.discord.com")) == k_discord,
+      "control: stock standard_hostkey WOULD fold updates.discord.com into discord.com's bucket")
+
+-- 5. Non-listed hosts are delegated to standard_hostkey unchanged.
+check(z2k_hostkey_split(mk("discord.com")) == "discord.com|4",
+      "non-listed host discord.com -> delegated (nld cut applied) 'discord.com|4'")
+check(z2k_hostkey_split(mk("www.google.com")) == "google.com|4",
+      "non-listed host www.google.com -> delegated 'google.com|4'")
+
+-- 6. A listed name arriving as an IP literal is NOT split (no real hostname).
+check(z2k_hostkey_split(mk("updates.discord.com", { is_ip = true })) == "IP",
+      "hostname_is_ip -> not split, delegated to host_ip fallback")
+
+-- 7. Degenerate input must not crash and must delegate.
+check(z2k_hostkey_split({}) == "IP",
+      "missing desync.track -> delegated, no crash")
+check(z2k_hostkey_split(nil) == "IP",
+      "nil desync -> delegated, no crash")
+
+print()
+print(string.format("Tests passed: %d / %d", PASS, PASS + FAIL))
+if FAIL > 0 then
+  os.exit(1)
+end

--- a/tests/test_z2k_hostkey_split.sh
+++ b/tests/test_z2k_hostkey_split.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# tests/test_z2k_hostkey_split.sh — обёртка над lua-харнесом
+# tests/test_z2k_hostkey_split.lua, чтобы общий прогон (tests/run_all.sh) и CI
+# видели его как обычный набор. Считает run_all.sh по строкам [PASS]/[FAIL],
+# которые печатает сам харнес. Без lua — [SKIP] (засчитывается и печатается
+# поимённо, не маскируется под [PASS]): в CI lua есть.
+LUA=""
+for c in lua5.3 lua5.4 lua luajit; do
+    if command -v "$c" >/dev/null 2>&1; then LUA=$c; break; fi
+done
+if [ -z "$LUA" ]; then
+    printf '[SKIP] lua не найден — test_z2k_hostkey_split.lua не запущен\n'
+    exit 0
+fi
+cd "$(dirname "$0")/.." || exit 1
+exec "$LUA" tests/test_z2k_hostkey_split.lua


### PR DESCRIPTION
## Что

Отдельным хостам rkn — своя ячейка ротации `circular`, без отдельного профиля.
Заменяет #55 (custom-profiles) по итогам разбора там: причина общего ключа —
`nld=2`, штатное средство — `hostkey=`.

- `z2k_hostkey_split` в `files/lua/z2k-modern-core.lua`, рядом с
  `z2k_nohost_key`: хостам из списка `Z2K_HOSTKEY_SPLIT` (сейчас один —
  `updates.discord.com`) отдаёт ключ = полный хост, минуя nld-cut, с тем же
  суффиксом `|4`/`|6` от `family_split`; всем прочим — нетронутый
  `standard_hostkey`. Для остального пула это no-op.
- `ensure_circular_hostkey_split` в `lib/config_official.sh` вешает
  `hostkey=z2k_hostkey_split` на circular-директиву `rkn_tcp`. Только rkn:
  это пул, куда попадает `updates.discord.com`. Идемпотентна, явно заданный
  `hostkey=` (например `z2k_nohost_key`) не перетирает. Стоит после
  `ensure_circular_nld2`, раньше `doc_args`/`in_range` — те сохраняют
  неизвестные им аргументы circular (`$rest`), поэтому `hostkey=` доезжает до
  движка.

## Зачем

`updates.discord.com` (Rust/rustls-апдейтер, приветствие ~1.8 КБ) под `nld=2`
схлопывается в `discord.com` и делит с ним ячейку `rkn_tcp`. Плечи им нужны
разные (ниже — замер), одной ячейкой оба хоста не обслужить.

## Что даёт по сравнению с профилем

Ничего не добавляется в `NFQWS2_OPT`; `updates.discord.com` едет по общему
арсеналу rkn и ротируется сам; «заморозить» в панели пинит найденное плечо
штатно по паре (пул, ключ); `$wl_excl` и переустановка работают как для любого
хоста rkn. Пункты 1, 2, 4 из разбора #55 снимаются самим подходом. Пункт 3
(`--dry-run` кандидата перед подменой конфига) — отдельным PR, он чинит и
`custom-strategies`.

## Тесты

- `tests/test_z2k_hostkey_split.lua` — 11 кейсов на настоящем
  `z2k-modern-core.lua` (`dofile`, сток `standard_hostkey` застаблен по
  контракту nld-cut + `|4`/`|6`): свой ключ у listed-хоста, `|4`/`|6`,
  `family_split=0`, изоляция от `discord.com` с контролем «сток бы схлопнул»,
  делегирование прочих, IP-литерал и degenerate-вход не падают. Прогнано на
  Lua 5.3.6 и 5.4.2 — 11/11.
- Обёртка `tests/test_z2k_hostkey_split.sh` (по образцу `test_tcp16_lua.sh`) —
  чтобы `run_all.sh` и CI набор видели; без lua печатает `[SKIP]`, не `[PASS]`.
  Добавлен в явные списки `ci.yml` и `scripts/ci_local.sh`.
- `tests/test_config_official.sh` — юнит `ensure_circular_hostkey_split`
  (добавляет, идемпотентна, не перетирает явный `hostkey=`) + e2e через
  настоящий `run_generator`: `hostkey=` на circular rkn, не задвоен, `yt_tcp`
  не тронут. 124/0.
- `.luacheckrc`: `z2k_hostkey_split` в globals.

## Проверено вживую

Keenetic (KeeneticOS 5.1.5), z2k p-84.3, движок `v1.0.5.1-z2k-r2`. В
`state.tsv` две независимые строки: `rkn_tcp discord.com|4` и
`rkn_tcp updates.discord.com|4`.

- Плечо **22** rkn (`tls_client_hello_clone` blob `z2k_real_www_microsoft_com`
  + `fake`) пробивает апдейтер — то же, что было в профиле из #55, то есть
  плечо арсенальное, сочинять ничего не пришлось.
- Плечо **19** (`syndata` + `multidisorder` + клон) апдейтер **не** пробивает,
  хотя браузерный `discord.com` на нём живёт: клиент висел на «Starting…»,
  переморозка ключа `updates.discord.com|4` на 22 — пробило сразу. Разные
  плечи для соседей одного домена — факт, а не гипотеза.
- `discord.com` в браузере остался на своём ключе и своём плече, не трогался.

## Не вошло

Список хостов лежит в коде (`Z2K_HOSTKEY_SPLIT`). Пока в нём один хост — так
проще и ничего не читается с диска. Если захочется файл в `lists/`, сделаю
следом.
